### PR TITLE
Fix binary location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 project (pantheon-agent-polkit)
-
 cmake_minimum_required (VERSION 2.8)
+
+include (GNUInstallDirs)
 
 set (DATADIR "${CMAKE_INSTALL_PREFIX}/share")
 set (PKGDATADIR "${DATADIR}/${CMAKE_PROJECT_NAME}")
@@ -9,8 +10,7 @@ set (EXEC_NAME ${CMAKE_PROJECT_NAME})
 set (VERSION "0.1.2")
 set (DOLLAR "$")
 
-set (LIBDIR "${CMAKE_INSTALL_PREFIX}/lib")
-set (EXECDIR "${LIBDIR}/policykit-1-pantheon")
+set (PKEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/policykit-1-pantheon")
 
 add_definitions (-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\")
 add_definitions (-w)

--- a/data/org.pantheon.agent-polkit.desktop.in.in
+++ b/data/org.pantheon.agent-polkit.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 _Name=Authentication Dialog
-Exec=${LIBDIR}/policykit-1-pantheon/pantheon-agent-polkit 
+Exec=${PKEXECDIR}/pantheon-agent-polkit 
 Icon=dialog-password
 Terminal=false
 Type=Application

--- a/data/org.pantheon.agent-polkit.desktop.in.in
+++ b/data/org.pantheon.agent-polkit.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 _Name=Authentication Dialog
-Exec=${PKEXECDIR}/pantheon-agent-polkit 
+Exec=${PKEXECDIR}/${EXEC_NAME}
 Icon=dialog-password
 Terminal=false
 Type=Application

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,5 +17,5 @@ OPTIONS
 add_executable (${EXEC_NAME} ${VALA_C})
 target_link_libraries (${EXEC_NAME} ${DEPS_LIBRARIES})
 
-install (TARGETS ${EXEC_NAME} DESTINATION ${EXECDIR})
+install (TARGETS ${EXEC_NAME} DESTINATION ${PKEXECDIR})
 


### PR DESCRIPTION
Fixes #2.

Instead of hardcoding the path, use CMAKE_INSTALL_FULL_LIBEXECDIR to install the binary to the right path, in addition to that, the exec name in desktop file is replaced with EXEC_NAME.