### PR TITLE
Fix #1 and #7

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(Translations)
 
+configure_file(org.pantheon.agent-polkit-daemon.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.agent-polkit-daemon.desktop)
 configure_file(org.pantheon.agent-polkit.desktop.in.in ${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.agent-polkit.desktop.in)
 configure_file_translation(${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.agent-polkit.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.agent-polkit.desktop ${CMAKE_SOURCE_DIR}/po/)
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.agent-polkit.desktop DESTINATION share/applications)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.agent-polkit-daemon.desktop DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/xdg/autostart)

--- a/data/org.pantheon.agent-polkit-daemon.desktop.in
+++ b/data/org.pantheon.agent-polkit-daemon.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=PolicyKit Authentication Agent
+Comment=PolicyKit Authentication Agent
+Exec=${PKEXECDIR}/${EXEC_NAME}
+Terminal=false
+Type=Application
+Categories=
+NoDisplay=true
+OnlyShowIn=Pantheon;
+X-GNOME-AutoRestart=true
+AutostartCondition=GNOME3 unless-session gnome


### PR DESCRIPTION
Adds the autostart .desktop file to /etc/xdg/autostart and fixes recent breakage in launching the agent itself.