### PR TITLE
Fix closing not cancelling

### DIFF
--- a/src/PolkitDialog.vala
+++ b/src/PolkitDialog.vala
@@ -134,6 +134,8 @@ namespace Ag.Widgets {
             action_area.margin_top = 14;
 
             key_release_event.connect (on_key_release);
+            close.connect (cancel);
+            
             update_idents ();
             select_session ();
         }
@@ -318,9 +320,6 @@ namespace Ag.Widgets {
 
         private bool on_key_release (Gdk.EventKey key) {
             switch (key.keyval) {
-                case Gdk.Key.Escape:
-                    cancel ();
-                    return Gdk.EVENT_STOP;
                 case Gdk.Key.KP_Enter:
                 case Gdk.Key.Return:
                     authenticate ();


### PR DESCRIPTION
There was a problem where hitting escape would not cancel the operation and only close the dialog. You can reproduce this with e.g: launching an action in AppCenter, and hitting escape. AppCenter will still show "Cancel" as the title of the button you've just clicked because polkit hasn't got any response. This is because Gtk already does the binding for escape to the `close` signal. Instead of handling that case in `on_key_release` we just bind the `cancel` method to `close` signal.