### PR TITLE
control: Provide polkit virtual package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,5 +16,6 @@ Package: pantheon-agent-polkit
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends}
+Provides: polkit-1-auth-agent
 Description: Polkit authorization designed for Pantheon
  An agent for Polkit authorization designed for Pantheon desktop environment.


### PR DESCRIPTION
See https://packages.debian.org/stretch/polkit-1-auth-agent

Lets other packages know that this provides polkit agent functionality, so it can be used as a dependency

It's possible that this fixes 
https://github.com/elementary/os/issues/352