### PR TITLE
PolkitDialog: use new dialog design from Portals

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,0 +1,20 @@
+.dialog toolbox box.top,
+.dialog toolbox box.bottom {
+    padding: 1rem;
+}
+
+.dialog toolbox .top overlay {
+    min-width: calc((48px * 2) - 1em);
+}
+
+.dialog toolbox .top .large-icons {
+    -gtk-icon-size: 48px;
+}
+
+.dialog toolbox .bottom button {
+    min-width: 5em;
+}
+
+.dialog toolbox > box {
+    padding: 1rem;
+}

--- a/data/gresource.xml
+++ b/data/gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/elementary/PolkitAgent">
+    <file compressed="true">Application.css</file>
+  </gresource>
+</gresources>

--- a/data/meson.build
+++ b/data/meson.build
@@ -22,6 +22,11 @@ i18n.merge_file(
     po_dir: meson.project_source_root () / 'po' / 'extra'
 )
 
+gresource = gnome.compile_resources(
+    'gresource',
+    'gresource.xml'
+)
+
 systemd_user_unit_dir = get_option('systemduserunitdir')
 
 if systemd_user_unit_dir != 'no'

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,16 @@ project(
 )
 
 install_path = join_paths(get_option('prefix'), get_option('libexecdir'), 'policykit-1-pantheon')
+gnome = import('gnome')
 i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language:'c')
+
+conf_data = configuration_data()
+conf_data.set('EXEC_NAME', meson.project_name())
+conf_data.set('PKEXECDIR', install_path)
+
+subdir('data')
 
 executable(
     meson.project_name(),
@@ -19,7 +26,9 @@ executable(
     'src/GcrPrompt.vala',
     'src/Agent.vala',
     'src/PolkitDialog.vala',
+    'src' / 'PortalDialog.vala',
     'src/Interfaces.vala',
+    gresource,
     dependencies: [
         dependency('libadwaita-1'),
         dependency('gcr-4'),
@@ -40,9 +49,4 @@ executable(
     install_dir: install_path
 )
 
-conf_data = configuration_data()
-conf_data.set('EXEC_NAME', meson.project_name())
-conf_data.set('PKEXECDIR', install_path)
-
-subdir('data')
 subdir('po')

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,3 +2,4 @@ src/Agent.vala
 src/Application.vala
 src/Interfaces.vala
 src/PolkitDialog.vala
+src/PortalDialog.vala

--- a/src/PolkitDialog.vala
+++ b/src/PolkitDialog.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2015-2019 elementary, Inc. (https://elementary.io)
+ * Copyright (c) 2015-2026 elementary, Inc. (https://elementary.io)
  * Copyright (C) 2015-2016 Ikey Doherty <ikey@solus-project.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,7 +23,7 @@
  * https://github.com/solus-project/budgie-desktop
  */
 
-public class Ag.PolkitDialog : Granite.MessageDialog, PantheonWayland.ExtendedBehavior {
+public class Ag.PolkitDialog : PortalDialog {
     public signal void done ();
     public bool was_canceled = false;
 
@@ -48,16 +48,12 @@ public class Ag.PolkitDialog : Granite.MessageDialog, PantheonWayland.ExtendedBe
 
     public PolkitDialog (string message, string icon_name, string _cookie,
                          List<Polkit.Identity?>? _idents, GLib.Cancellable _cancellable) {
-        Object (
-            title: _("Authentication Dialog")
-        );
-
         idents = _idents;
         cookie = _cookie;
         cancellable = _cancellable;
         cancellable.cancelled.connect (cancel);
 
-        primary_text = _("Authentication Required");
+        title = _("Authentication Required");
         secondary_text = message;
 
         password_entry = new Gtk.PasswordEntry () {
@@ -98,39 +94,30 @@ public class Ag.PolkitDialog : Granite.MessageDialog, PantheonWayland.ExtendedBe
         credentials_box.append (password_entry);
         credentials_box.append (feedback_revealer);
 
-        image_icon = new ThemedIcon ("dialog-password");
+        secondary_icon = new ThemedIcon ("dialog-password");
 
         if (icon_name != "" && Gtk.IconTheme.get_for_display (Gdk.Display.get_default ()).has_icon (icon_name)) {
-            badge_icon = new ThemedIcon (icon_name);
+            primary_icon = new ThemedIcon (icon_name);
         }
 
-        custom_bin.append (credentials_box);
-
-        var cancel_button = (Gtk.Button)add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
-        cancel_button.clicked.connect (() => cancel ());
-
-        var authenticate_button = (Gtk.Button)add_button (_("Authenticate"), Gtk.ResponseType.APPLY);
-        authenticate_button.receives_default = true;
-        authenticate_button.add_css_class (Granite.CssClass.SUGGESTED);
-        authenticate_button.clicked.connect (authenticate);
-
-        default_widget = authenticate_button;
+        allow_label = _("Authenticate");
+        cancel_label = _("Cancel");
+        content = credentials_box;
         focus_widget = password_entry;
-
-        close.connect (cancel);
+        resizable = false;
 
         update_idents ();
         select_session ();
 
-        child.realize.connect (() => {
-            connect_to_shell ();
-            set_keep_above ();
-            make_centered ();
-            make_modal (true);
-
-            var surface = get_surface ();
-            if (surface is Gdk.Toplevel) {
-                ((Gdk.Toplevel) surface).inhibit_system_shortcuts (null);
+        response.connect ((response) => {
+            switch (response) {
+                case ALLOW:
+                    authenticate ();
+                    break;
+                case CANCEL:
+                case DELETE_EVENT:
+                    cancel ();
+                    break;
             }
         });
     }

--- a/src/PortalDialog.vala
+++ b/src/PortalDialog.vala
@@ -1,0 +1,177 @@
+/*
+ * SPDX-FileCopyrightText: 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+public class Ag.PortalDialog : Gtk.Window, PantheonWayland.ExtendedBehavior {
+    /**
+     * The {@link PortalDialog.ResponseType} that has been selected by the user
+     */
+    public signal void response (ResponseType response);
+
+    /**
+     * The {@link GLib.Icon} that is used to display the primary_icon representing the app making the request
+     */
+    public GLib.Icon primary_icon { get; set; }
+
+    /**
+     * The {@link GLib.Icon} that is used to display a secondary_icon representing the action to be performed
+     */
+    public GLib.Icon secondary_icon { get; set; }
+
+    /**
+     * The secondary text, body of the dialog.
+     */
+    public string secondary_text { get; set; }
+
+    /**
+     * The child widget for the content area
+     */
+    public Gtk.Widget content { get; set; }
+
+    /**
+     * The label of the button which denies access
+     */
+    public string cancel_label { get; set; }
+
+    /**
+     * The label of the button which allows access
+     */
+    public string allow_label { get; set; }
+
+    /**
+     * Whether the allow button should be disabled
+     */
+    public bool form_valid { get; set; default = true; }
+
+    public ActionType action_type { get; set; default = SUGGESTED; }
+
+    public enum ActionType {
+        SUGGESTED,
+        DESTRUCTIVE
+    }
+
+    public enum ResponseType {
+        ALLOW,
+        CANCEL,
+        DELETE_EVENT;
+
+        // Convert to response ID expected by portal backends
+        public uint32 to_id () {
+            switch (this) {
+                case ALLOW:
+                    return 0;
+                case CANCEL:
+                    return 1;
+                default:
+                case DELETE_EVENT:
+                    return 2;
+            }
+        }
+    }
+
+    /**
+     * The parent window identifier as described by https://flatpak.github.io/xdg-desktop-portal/docs/window-identifiers.html
+     */
+    public string parent_handle { get; set; }
+
+    private Granite.Box button_box;
+
+    construct {
+        var primary_icon = new Gtk.Image.from_icon_name ("application-default-icon") {
+            halign = START,
+            icon_size = LARGE
+        };
+
+        var secondary_icon = new Gtk.Image.from_icon_name ("preferences-system-privacy") {
+            halign = END,
+            icon_size = LARGE
+        };
+
+        var overlay = new Gtk.Overlay () {
+            child = secondary_icon,
+            halign = CENTER
+        };
+        overlay.add_overlay (primary_icon);
+
+        var header_label = new Granite.HeaderLabel ("") {
+            size = H3
+        };
+
+        var header = new Granite.Box (VERTICAL);
+        header.append (overlay);
+        header.append (header_label);
+
+        var cancel_button = new Gtk.Button.with_label (_("Don't Allow"));
+
+        var allow_button = new Gtk.Button.with_label (_("Allow")) {
+            receives_default = true
+        };
+        allow_button.add_css_class (Granite.CssClass.SUGGESTED);
+
+        button_box = new Granite.Box (HORIZONTAL, HALF) {
+            homogeneous = true,
+            valign = END
+        };
+        button_box.append (cancel_button);
+        button_box.append (allow_button);
+
+        var toolbarview = new Granite.ToolBox ();
+        toolbarview.add_bottom_bar (button_box);
+        toolbarview.add_top_bar (header);
+
+        child = toolbarview;
+
+        default_width = 325;
+        default_widget = allow_button;
+        modal = true;
+
+        // We need to hide the title area
+        titlebar = new Gtk.Grid () {
+            visible = false
+        };
+
+        add_css_class ("dialog");
+
+        bind_property ("primary-icon", primary_icon, "gicon");
+        bind_property ("secondary-icon", secondary_icon, "gicon");
+        bind_property ("content", toolbarview, "content");
+        bind_property ("title", header_label, "label");
+        bind_property ("secondary-text", header_label, "secondary-text");
+        bind_property ("form-valid", allow_button, "sensitive");
+        bind_property ("allow-label", allow_button, "label");
+        bind_property ("cancel-label", cancel_button, "label");
+
+        notify["action-type"].connect (() => {
+            if (action_type == SUGGESTED) {
+                allow_button.add_css_class (Granite.CssClass.SUGGESTED);
+                cancel_button.receives_default = false;
+                allow_button.receives_default = true;
+                default_widget = allow_button;
+            } else {
+                allow_button.add_css_class (Granite.CssClass.DESTRUCTIVE);
+                allow_button.receives_default = false;
+                cancel_button.receives_default = true;
+                default_widget = cancel_button;
+            }
+        });
+
+        child.realize.connect (on_realize);
+
+        allow_button.clicked.connect (() => response (ALLOW));
+        cancel_button.clicked.connect (() => response (CANCEL));
+        close_request.connect (() => { response (DELETE_EVENT); });
+    }
+
+    private void on_realize () {
+        connect_to_shell ();
+        set_keep_above ();
+        make_centered ();
+        make_modal (true);
+
+        var surface = get_surface ();
+        if (surface is Gdk.Toplevel) {
+            ((Gdk.Toplevel) surface).inhibit_system_shortcuts (null);
+        }
+    }
+}


### PR DESCRIPTION
Until we land https://github.com/elementary/granite/pull/972, copy the PortalDialog

<img width="379" height="324" alt="Screenshot from 2026-08-03 12 01 49" src="https://github.com/user-attachments/assets/4c6f4940-b65c-4d50-b048-e763f6668de9" />
<img width="379" height="324" alt="Screenshot from 2026-08-03 12 02 47" src="https://github.com/user-attachments/assets/3e267e00-8933-4b78-8b9f-f6c40fe4cdf0" />
